### PR TITLE
Add Dependabot and Coveralls

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-pro

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,7 @@
+---
+version: 1
+
+update_configs:
+  - package_manager: 'ruby:bundler'
+    directory: '/'
+    update_schedule: 'daily'

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ build/
 
 ## Environment normalisation:
 /.bundle/
+/vendor/
 /lib/bundler/man/
 
 # for a library or gem, you might want to ignore these files since the code is

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gemspec
 gem 'rake', :require => false
 
 group :test do
+  gem 'coveralls', '~> 0.8.23'
   gem 'pry'
   gem 'rb-readline'
   gem 'rspec', '~> 3.5.0'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # vmfloaty
 
-[![Gem Version](https://badge.fury.io/rb/vmfloaty.svg)](https://badge.fury.io/rb/vmfloaty) [![Build Status](https://travis-ci.com/puppetlabs/vmfloaty.svg?branch=master)](https://travis-ci.com/puppetlabs/vmfloaty)
+[![Gem Version](https://badge.fury.io/rb/vmfloaty.svg)](https://badge.fury.io/rb/vmfloaty)
+[![Build Status](https://travis-ci.com/puppetlabs/vmfloaty.svg?branch=master)](https://travis-ci.com/puppetlabs/vmfloaty)
+[![Coverage Status](https://coveralls.io/repos/github/puppetlabs/vmfloaty/badge.svg?branch=master)](https://coveralls.io/github/puppetlabs/vmfloaty?branch=master)
+[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=puppetlabs/vmfloaty)](https://dependabot.com)
 
 A CLI helper tool for [Puppet's vmpooler](https://github.com/puppetlabs/vmpooler) to help you stay afloat.
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+require 'coveralls'
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+])
+SimpleCov.start do
+  add_filter %r{^/spec/}
+end
+
 require 'vmfloaty'
 require 'webmock/rspec'
 


### PR DESCRIPTION
This adds Dependabot to keep things updated and Coveralls so we can see how code coverage changes over time. Coveralls / SimpleCov are configured so that both the SimpleCov html report and the Coveralls report are generated. This facilitates easily seeing coverage locally in addtion to via CI.

This PR builds on the code in #69