### PR TITLE
Add support for on demand provisioning to vmfloaty

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+**/*.yml
+**/*.yaml
+**/*.md
+**/*example
+**/Dockerfile*
+Gemfile.lock
+Rakefile
+coverage
+spec
+examples
+scripts
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:2.7
+
+COPY ./ ./
+
+RUN apt-get update && apt-get install -y less
+RUN gem install bundler && bundle install && gem build vmfloaty.gemspec && gem install vmfloaty*.gem

--- a/lib/vmfloaty/abs.rb
+++ b/lib/vmfloaty/abs.rb
@@ -150,6 +150,14 @@ class ABS
     os_list << '*** VMPOOLER Pools ***'
     os_list += JSON.parse(res_body['vmpooler_platforms'])
 
+    res = conn.get 'status/platforms/ondemand_vmpooler'
+    res_body = JSON.parse(res.body)
+    unless res_body['ondemand_vmpooler_platforms'] == '[]'
+      os_list << ''
+      os_list << '*** VMPOOLER ONDEMAND Pools ***'
+      os_list += JSON.parse(res_body['ondemand_vmpooler_platforms'])
+    end
+
     res = conn.get 'status/platforms/nspooler'
     res_body = JSON.parse(res.body)
     os_list << ''
@@ -168,7 +176,7 @@ class ABS
   end
 
   # Retrieve an OS from ABS.
-  def self.retrieve(verbose, os_types, token, url, user, options)
+  def self.retrieve(verbose, os_types, token, url, user, options, _ondemand = nil)
     #
     # Contents of post must be like:
     #

--- a/lib/vmfloaty/service.rb
+++ b/lib/vmfloaty/service.rb
@@ -75,10 +75,14 @@ class Service
     @service_object.list_active verbose, url, token, user
   end
 
-  def retrieve(verbose, os_types, use_token = true)
+  def retrieve(verbose, os_types, use_token = true, ondemand = nil)
     puts 'Requesting a vm without a token...' unless use_token
     token_value = use_token ? token : nil
-    @service_object.retrieve verbose, os_types, token_value, url, user, @config
+    @service_object.retrieve verbose, os_types, token_value, url, user, @config, ondemand
+  end
+
+  def wait_for_request(verbose, requestid)
+    @service_object.wait_for_request verbose, requestid, url
   end
 
   def ssh(verbose, host_os, use_token = true)

--- a/lib/vmfloaty/utils.rb
+++ b/lib/vmfloaty/utils.rb
@@ -45,7 +45,9 @@ class Utils
 
     result = {}
 
-    response_body.each do |os, value|
+    STDOUT.puts "response body is #{response_body}"
+    filtered_response_body = response_body.reject { |key, _| key == 'request_id' || key == 'ready' }
+    filtered_response_body.each do |os, value|
       hostnames = Array(value['hostname'])
       hostnames.map! { |host| "#{host}.#{domain}" } if domain
       result[os] = hostnames

--- a/spec/vmfloaty/pooler_spec.rb
+++ b/spec/vmfloaty/pooler_spec.rb
@@ -84,6 +84,26 @@ describe Pooler do
       expect(vm_req['debian-7-i386']['hostname']).to eq %w[sc0o4xqtodlul5w 4m4dkhqiufnjmxy]
       expect(vm_req['centos-7-x86_64']['hostname']).to eq 'zb91y9qbrbf6d3q'
     end
+
+    context 'with ondemand provisioning' do
+      let(:ondemand_response) { '{"ok":true,"request_id":"1234"}' }
+      it 'retreives the vm with a token' do
+        stub_request(:post, "#{@vmpooler_url}/ondemandvm/debian-7-i386")
+          .with(:headers => { 'X-Auth-Token' => 'mytokenfile' })
+          .to_return(:status => 200, :body => ondemand_response, :headers => {})
+
+        stub_request(:get, "#{@vmpooler_url}/ondemandvm/1234")
+          .to_return(:status => 200, :body => @retrieve_response_body_single, :headers => {})
+
+        vm_hash = {}
+        vm_hash['debian-7-i386'] = 1
+        Pooler.retrieve(false, vm_hash, 'mytokenfile', @vmpooler_url, 'user', {}, true)
+        vm_req = Pooler.check_ondemandvm(false, '1234', @vmpooler_url)
+        expect(vm_req).to be_an_instance_of Hash
+        expect(vm_req['ok']).to equal true
+        expect(vm_req['debian-7-i386']['hostname']).to eq 'fq6qlpjlsskycq6'
+      end
+    end
   end
 
   describe '#modify' do


### PR DESCRIPTION
## Status

Ready for merge

## Description

This commit adds support for provisioning instances on demand with vmpooler. Additionally, this change adds a capability to detect on demand pools available in ABS. Without this change vmfloaty does not support provisioning instances via the vmpooler ondemand endpoints.

## Reviewers

@puppetlabs/dio
@highb
@briancain
