### PR TITLE
Fix the argument list for nonstandardpooler

### DIFF
--- a/lib/vmfloaty/nonstandard_pooler.rb
+++ b/lib/vmfloaty/nonstandard_pooler.rb
@@ -22,7 +22,7 @@ class NonstandardPooler
     status['reserved_hosts'] || []
   end
 
-  def self.retrieve(verbose, os_type, token, url, _user, _options)
+  def self.retrieve(verbose, os_type, token, url, _user, _options, ondemand = nil)
     conn = Http.get_conn(verbose, url)
     conn.headers['X-AUTH-TOKEN'] = token if token
 


### PR DESCRIPTION
This PR fixes the following error in 0.10.0 when using `nonstandard_pooler`. The `ondemand` argument was added to the other `retrieve` methods but missed in `nonstandardpooler` causing failures when provisioning.

```
$ floaty get aix-7.2-power --service ns                                                                                       
error: wrong number of arguments (given 7, expected 6). Use --trace to view backtrace
```

## Status

[Ready for Merge]

## Description

* Fix an issue where nonstandard pooler was incompatible with the on demand provisioning changes

## Related Issues

- #67 

## Todos

- [ ] Tests
- [ ] Documentation

## Reviewers

@puppetlabs/dio
@highb
@briancain
