### PR TITLE
(maint) Fix using ABS service without a .vmfloaty.yml file

### DIFF
--- a/lib/vmfloaty/utils.rb
+++ b/lib/vmfloaty/utils.rb
@@ -206,6 +206,9 @@ class Utils
         # If the service is configured but some values are missing, use the top-level defaults to fill them in
         service_config.merge! config['services'][options.service]
       end
+    # No config file but service is declared on command line
+    elsif !config['services'] && options.service
+      service_config['type'] = options.service
     end
 
     # Prioritize an explicitly specified url, user, or token if the user provided one


### PR DESCRIPTION
If you do not use a config file, and define everything on the command line,
previously the service always defaulted to vmpooler. Even if you requested ABS.
This PR fixes that, now we'll see if the config has no service defined and we
defined on the command line a service, we'll use that service.

## Reviewers

@puppetlabs/dio
@highb
@briancain
