### PR TITLE
Add tab completion script for zsh and fix bash completion for ABS services

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ If you are running on macOS and use Homebrew's `bash-completion` formula, you ca
 ln -s $(floaty completion --shell bash) /usr/local/etc/bash_completion.d/floaty
 ```
 
+There is also tab completion for zsh:
+
+```zsh
+source $(floaty completion --shell zsh)
+```
+
 ## vmpooler API
 
 This cli tool uses the [vmpooler API](https://github.com/puppetlabs/vmpooler/blob/master/API.md).

--- a/extras/completions/floaty.bash
+++ b/extras/completions/floaty.bash
@@ -21,7 +21,7 @@ _vmfloaty()
 
     COMPREPLY=( $(compgen -W "${_vmfloaty_avail_templates}" -- "${cur}") )
   elif [[ $hostname_subcommands =~ (^| )$prev($| ) ]] ; then
-    _vmfloaty_active_hostnames=$(floaty list --active 2>/dev/null | grep '^-' | cut -d' ' -f2)
+    _vmfloaty_active_hostnames=$(floaty list --active --hostnameonly 2>/dev/null)
     COMPREPLY=( $(compgen -W "${_vmfloaty_active_hostnames}" -- "${cur}") )
   else
     COMPREPLY=( $(compgen -W "${subcommands}" -- "${cur}") )

--- a/extras/completions/floaty.zsh
+++ b/extras/completions/floaty.zsh
@@ -1,0 +1,37 @@
+_floaty()
+{
+  local line subcommands template_subcommands hostname_subcommands
+
+  subcommands="delete get help list modify query revert snapshot ssh status summary token"
+
+  template_subcommands=("get" "ssh")
+  hostname_subcommands=("delete" "modify" "query" "revert" "snapshot")
+
+  _arguments -C \
+    "1: :(${subcommands})" \
+    "*::arg:->args"
+
+  if ((template_subcommands[(Ie)$line[1]])); then
+    _floaty_template_sub
+  elif ((hostname_subcommands[(Ie)$line[1]])); then
+    _floaty_hostname_sub
+  fi
+}
+
+_floaty_template_sub()
+{
+  if [[ -z "$_vmfloaty_avail_templates" ]] ; then
+    _vmfloaty_avail_templates=$(floaty list 2>/dev/null)
+  fi
+
+  _arguments "1: :(${_vmfloaty_avail_templates})"
+}
+
+_floaty_hostname_sub()
+{
+  _vmfloaty_active_hostnames=$(floaty list --active --hostnameonly 2>/dev/null)
+
+  _arguments "1: :(${_vmfloaty_active_hostnames})"
+}
+
+compdef _floaty floaty

--- a/lib/vmfloaty.rb
+++ b/lib/vmfloaty.rb
@@ -88,6 +88,7 @@ class Vmfloaty
       c.option '--service STRING', String, 'Configured pooler service name'
       c.option '--active', 'Prints information about active vms for a given token'
       c.option '--json', 'Prints information as JSON'
+      c.option '--hostnameonly', 'When listing active vms, prints only hostnames, one per line'
       c.option '--token STRING', String, 'Token for pooler service'
       c.option '--url STRING', String, 'URL of pooler service'
       c.option '--user STRING', String, 'User to authenticate with'
@@ -115,6 +116,10 @@ class Vmfloaty
           else
             if options.json
               puts Utils.get_host_data(verbose, service, running_vms).to_json
+            elsif options.hostnameonly
+              Utils.get_host_data(verbose, service, running_vms).each do |hostname, host_data|
+                Utils.print_fqdn_for_host(service, hostname, host_data)
+              end
             else
               puts "Your VMs on #{host}:"
               Utils.pretty_print_hosts(verbose, service, running_vms)

--- a/lib/vmfloaty/utils.rb
+++ b/lib/vmfloaty/utils.rb
@@ -87,9 +87,13 @@ class Utils
   def self.print_fqdn_for_host(service, hostname, host_data)
     case service.type
     when 'ABS'
+      abs_hostnames = []
+
       host_data['allocated_resources'].each do |vm_name, _i|
-        puts vm_name['hostname']
+        abs_hostnames << vm_name['hostname']
       end
+
+      puts abs_hostnames.join("\n")
     when 'Pooler'
       puts "#{hostname}.#{host_data['domain']}"
     when 'NonstandardPooler'

--- a/lib/vmfloaty/utils.rb
+++ b/lib/vmfloaty/utils.rb
@@ -114,13 +114,17 @@ class Utils
         #
         # Create a vmpooler service to query each hostname there so as to get the metadata too
 
-        vmpooler_service = service.clone
-        vmpooler_service.silent = true
-        vmpooler_service.maybe_use_vmpooler
         output_target.puts "- [JobID:#{host_data['request']['job']['id']}] <#{host_data['state']}>"
-
-        host_data['allocated_resources'].each do |vm_name, _i|
-          self.pretty_print_hosts(verbose, vmpooler_service, vm_name['hostname'].split('.')[0], print_to_stderr, indent+2)
+        host_data['allocated_resources'].each do |allocated_resources, _i|
+          if allocated_resources['engine'] == "vmpooler"
+            vmpooler_service = service.clone
+            vmpooler_service.silent = true
+            vmpooler_service.maybe_use_vmpooler
+            self.pretty_print_hosts(verbose, vmpooler_service, allocated_resources['hostname'].split('.')[0], print_to_stderr, indent+2)
+          else
+            #TODO we could add more specific metadata for the other services, nspooler and aws
+            output_target.puts "  - #{allocated_resources['hostname']} (#{allocated_resources['type']})"
+          end
         end
       when 'Pooler'
         tag_pairs = []

--- a/lib/vmfloaty/utils.rb
+++ b/lib/vmfloaty/utils.rb
@@ -84,6 +84,21 @@ class Utils
     os_types
   end
 
+  def self.print_fqdn_for_host(service, hostname, host_data)
+    case service.type
+    when 'ABS'
+      host_data['allocated_resources'].each do |vm_name, _i|
+        puts vm_name['hostname']
+      end
+    when 'Pooler'
+      puts "#{hostname}.#{host_data['domain']}"
+    when 'NonstandardPooler'
+      puts host_data['fqdn']
+    else
+      raise "Invalid service type #{service.type}"
+    end
+  end
+
   def self.pretty_print_hosts(verbose, service, hostnames = [], print_to_stderr = false, indent = 0)
     output_target = print_to_stderr ? $stderr : $stdout
 

--- a/spec/vmfloaty/utils_spec.rb
+++ b/spec/vmfloaty/utils_spec.rb
@@ -387,6 +387,7 @@ describe Utils do
 
       let(:hostname) { '1597952189390' }
       let(:fqdn) { 'example-noun.delivery.puppetlabs.net' }
+      let(:fqdn_hostname) {'example-noun'}
       let(:template) { 'ubuntu-1604-x86_64' }
 
       # This seems to be the miminal stub response from ABS for the current output
@@ -410,17 +411,41 @@ describe Utils do
         }
       end
 
-      let(:default_output) { "- [JobID:#{hostname}] #{fqdn} (#{template}) <allocated>" }
+      # The vmpooler response contains metadata that is printed
+      let(:domain) { 'delivery.mycompany.net' }
+      let(:response_body_vmpooler) do
+        {
+            fqdn_hostname => {
+                'template' => 'redhat-7-x86_64',
+                'lifetime' => 48,
+                'running'  => 7.67,
+                'state'    => 'running',
+                'tags'     => {
+                    'user' => 'bob',
+                    'role' => 'agent',
+                },
+                'ip'       => '127.0.0.1',
+                'domain'   => domain,
+            }
+        }
+      end
 
       before(:each) do
         allow(Utils).to receive(:get_vmpooler_service_config).and_return({
           'url' => 'http://vmpooler.example.com',
           'token' => 'krypto-knight'
         })
+        allow(service).to receive(:query)
+                              .with(anything, fqdn_hostname)
+                              .and_return(response_body_vmpooler)
       end
 
+      let(:default_output_first_line) { "- [JobID:#{hostname}] <allocated>" }
+      let(:default_output_second_line) { "  - example-noun.delivery.mycompany.net (redhat-7-x86_64, 7.67/48 hours, user: bob, role: agent)" }
+
       it 'prints output with job id, host, and template' do
-        expect(STDOUT).to receive(:puts).with(default_output)
+        expect(STDOUT).to receive(:puts).with(default_output_first_line)
+        expect(STDOUT).to receive(:puts).with(default_output_second_line)
 
         subject
       end
@@ -429,7 +454,8 @@ describe Utils do
         let(:print_to_stderr) { true }
 
         it 'outputs to stderr instead of stdout' do
-          expect(STDERR).to receive(:puts).with(default_output)
+          expect(STDERR).to receive(:puts).with(default_output_first_line)
+          expect(STDERR).to receive(:puts).with(default_output_second_line)
 
           subject
         end

--- a/spec/vmfloaty/utils_spec.rb
+++ b/spec/vmfloaty/utils_spec.rb
@@ -162,6 +162,89 @@ describe Utils do
     end
   end
 
+  describe '#print_fqdn_for_host' do
+    let(:url) { 'http://pooler.example.com' }
+
+    subject { Utils.print_fqdn_for_host(service, hostname, host_data) }
+
+    describe 'with vmpooler host' do
+      let(:service) { Service.new(MockOptions.new, 'url' => url) }
+      let(:hostname) { 'mcpy42eqjxli9g2' }
+      let(:domain) { 'delivery.mycompany.net' }
+      let(:fqdn) { [hostname, domain].join('.') }
+
+      let(:host_data) do
+        {
+          'template' => 'ubuntu-1604-x86_64',
+          'lifetime' => 12,
+          'running'  => 9.66,
+          'state'    => 'running',
+          'ip'       => '127.0.0.1',
+          'domain'   => domain,
+        }
+      end
+
+      it 'outputs fqdn for host' do
+        expect(STDOUT).to receive(:puts).with(fqdn)
+
+        subject
+      end
+    end
+
+    describe 'with nonstandard pooler host' do
+      let(:service) { Service.new(MockOptions.new, 'url' => url, 'type' => 'ns') }
+      let(:hostname) { 'sol11-9.delivery.mycompany.net' }
+      let(:host_data) do
+        {
+          'fqdn'                      => hostname,
+          'os_triple'                 => 'solaris-11-sparc',
+          'reserved_by_user'          => 'first.last',
+          'reserved_for_reason'       => '',
+          'hours_left_on_reservation' => 35.89,
+        }
+      end
+      let(:fqdn) { hostname } # for nspooler these are the same
+
+      it 'outputs fqdn for host' do
+        expect(STDOUT).to receive(:puts).with(fqdn)
+
+        subject
+      end
+    end
+
+    describe 'with ABS host' do
+      let(:service) { Service.new(MockOptions.new, 'url' => url, 'type' => 'abs') }
+      let(:hostname) { '1597952189390' }
+      let(:fqdn) { 'example-noun.delivery.puppetlabs.net' }
+      let(:template) { 'ubuntu-1604-x86_64' }
+
+      # This seems to be the miminal stub response from ABS for the current output
+      let(:host_data) do
+        {
+          'state' => 'allocated',
+          'allocated_resources' => [
+            {
+              'hostname' => fqdn,
+              'type' => template,
+              'enging' => 'vmpooler',
+            },
+          ],
+          'request' => {
+            'job' => {
+              'id' => hostname,
+            }
+          },
+        }
+      end
+
+      it 'outputs fqdn for host' do
+        expect(STDOUT).to receive(:puts).with(fqdn)
+
+        subject
+      end
+    end
+  end
+
   describe '#pretty_print_hosts' do
     let(:url) { 'http://pooler.example.com' }
 


### PR DESCRIPTION
## Status

Ready for Merge

## Description

Adds a new `--hostnameonly` option to `floaty list` to serve as more reliable plumbing for the completion scripts, then updates the bash completion script to use that option and implements a new zsh completion script with equivalent functionality to the bash script.

## Reviewers

@puppetlabs/dio
@highb
@briancain
