### PR TITLE
(maint) Remove warning about missing configuration file

### DIFF
--- a/lib/vmfloaty.rb
+++ b/lib/vmfloaty.rb
@@ -90,6 +90,7 @@ class Vmfloaty
       c.option '--json', 'Prints information as JSON'
       c.option '--token STRING', String, 'Token for pooler service'
       c.option '--url STRING', String, 'URL of pooler service'
+      c.option '--user STRING', String, 'User to authenticate with'
       c.action do |args, options|
         verbose = options.verbose || config['verbose']
 
@@ -212,6 +213,7 @@ class Vmfloaty
       c.option '--json', 'Outputs hosts scheduled for deletion as JSON'
       c.option '--token STRING', String, 'Token for pooler service'
       c.option '--url STRING', String, 'URL of pooler service'
+      c.option '--user STRING', String, 'User to authenticate with'
       c.action do |args, options|
         verbose = options.verbose || config['verbose']
         service = Service.new(options, config)

--- a/lib/vmfloaty.rb
+++ b/lib/vmfloaty.rb
@@ -20,7 +20,7 @@ class Vmfloaty
 
   def run # rubocop:disable Metrics/AbcSize
     program :version, Vmfloaty::VERSION
-    program :description, "A CLI helper tool for Puppet's vmpooler to help you stay afloat"
+    program :description, "A CLI helper tool for Puppet's vmpooler to help you stay afloat.\n\nConfiguration may be placed in a ~/.vmfloaty.yml file."
 
     config = Conf.read_config
 

--- a/lib/vmfloaty/conf.rb
+++ b/lib/vmfloaty/conf.rb
@@ -8,7 +8,7 @@ class Conf
     begin
       conf = YAML.load_file("#{Dir.home}/.vmfloaty.yml")
     rescue StandardError
-      FloatyLogger.warn "WARNING: There was no config file at #{Dir.home}/.vmfloaty.yml"
+      # ignore
     end
     conf
   end


### PR DESCRIPTION
Previously the CLI would emit a warning about missing configuration
file, but a configuration file does not appear to be a requirement, at
least based on the documentation and the fact that everything can be
specified directly on the command line.

This commit simply removes the warning.

Users will no longer get a warning when doing things like `floaty
--version`, `floaty help`, and any other subcommand.

## Reviewers

@puppetlabs/dio
@highb
@briancain
