### PR TITLE
WIP (DIO-911) Include job_id in ABS --json output

### DIFF
--- a/lib/vmfloaty.rb
+++ b/lib/vmfloaty.rb
@@ -90,6 +90,7 @@ class Vmfloaty
       c.option '--json', 'Prints information as JSON'
       c.option '--token STRING', String, 'Token for pooler service'
       c.option '--url STRING', String, 'URL of pooler service'
+      c.option '--user STRING', String, 'User to authenticate with'
       c.action do |args, options|
         verbose = options.verbose || config['verbose']
 
@@ -212,6 +213,7 @@ class Vmfloaty
       c.option '--json', 'Outputs hosts scheduled for deletion as JSON'
       c.option '--token STRING', String, 'Token for pooler service'
       c.option '--url STRING', String, 'URL of pooler service'
+      c.option '--user STRING', String, 'User to authenticate with'
       c.action do |args, options|
         verbose = options.verbose || config['verbose']
         service = Service.new(options, config)

--- a/lib/vmfloaty.rb
+++ b/lib/vmfloaty.rb
@@ -20,7 +20,7 @@ class Vmfloaty
 
   def run # rubocop:disable Metrics/AbcSize
     program :version, Vmfloaty::VERSION
-    program :description, "A CLI helper tool for Puppet's vmpooler to help you stay afloat"
+    program :description, "A CLI helper tool for Puppet's vmpooler to help you stay afloat.\n\nConfiguration may be placed in a ~/.vmfloaty.yml file."
 
     config = Conf.read_config
 

--- a/lib/vmfloaty/abs.rb
+++ b/lib/vmfloaty/abs.rb
@@ -233,7 +233,7 @@ class ABS
 
     (1..retries).each do |i|
       queue_place, res_body = check_queue(conn, saved_job_id, req_obj, verbose)
-      return translated(res_body) if res_body
+      return translated(res_body, saved_job_id) if res_body
 
       sleep_seconds = 10 if i >= 10
       sleep_seconds = i if i < 10
@@ -247,8 +247,8 @@ class ABS
   #
   # We should fix the ABS API to be more like the vmpooler or nspooler api, but for now
   #
-  def self.translated(res_body)
-    vmpooler_formatted_body = {}
+  def self.translated(res_body, job_id)
+    vmpooler_formatted_body = {'job_id' => job_id}
 
     res_body.each do |host|
       if vmpooler_formatted_body[host['type']] && vmpooler_formatted_body[host['type']]['hostname'].class == Array

--- a/lib/vmfloaty/conf.rb
+++ b/lib/vmfloaty/conf.rb
@@ -8,7 +8,7 @@ class Conf
     begin
       conf = YAML.load_file("#{Dir.home}/.vmfloaty.yml")
     rescue StandardError
-      FloatyLogger.warn "WARNING: There was no config file at #{Dir.home}/.vmfloaty.yml"
+      # ignore
     end
     conf
   end

--- a/lib/vmfloaty/utils.rb
+++ b/lib/vmfloaty/utils.rb
@@ -45,6 +45,10 @@ class Utils
 
     result = {}
 
+    # ABS has a job_id associated with hosts so pass that along
+    abs_job_id = response_body.delete('job_id')
+    result['job_id'] = abs_job_id unless abs_job_id.nil?
+
     filtered_response_body = response_body.reject { |key, _| key == 'request_id' || key == 'ready' }
     filtered_response_body.each do |os, value|
       hostnames = Array(value['hostname'])
@@ -57,7 +61,8 @@ class Utils
 
   def self.format_host_output(hosts)
     hosts.flat_map do |os, names|
-      names.map { |name| "- #{name} (#{os})" }
+      # Assume hosts are stored in Arrays and ignore everything else
+      names.map { |name| "- #{name} (#{os})" } if names.is_a? Array
     end.join("\n")
   end
 


### PR DESCRIPTION
Prior to this commit, when using --service=abs and --json the job_id
value is not included in the JSON blob, which makes it difficult for
calling code to grab both the job_id and the hosts without text
processing the log messages printed to standard error.

----

Based on #91 but not strictly related to those changes.

----

⚠️  I could use some design direction here, and determine how we want to update tests ⚠️ 

----

Prior to this change the output was:
```
$ floaty get centos-7-x86_64 --json
--
Requesting VMs with job_id: 1597884146476.  Will retry for up to an hour.
Waiting 1 seconds to check if ABS request has been filled.  Queue Position: 277... (x1)
Waiting 2 seconds to check if ABS request has been filled.  Queue Position: 277... (x2)
Waiting 3 seconds to check if ABS request has been filled.  Queue Position: 277... (x3)
Waiting 4 seconds to check if ABS request has been filled.  Queue Position: 277... (x4)
{
  "centos-7-x86_64": [
    "near-betterment.delivery.puppetlabs.net"
  ]
}
```

But that does not play well with calling code as the `job_id` value is very important, yet buried within the log message sent to stderr.

A calling script would have to capture stderr and text-match to extract the job_id.

The job_id is important because callers want to be good citizens and subsequently call `floaty delete <job_id>` to return everything back to the pool.

With these changes we now get the job_id included in the JSON blob:

```
$ floaty get --service=abs --user=nwolfe --token=**** centos-7-x86_64 --url=https://cinext-abs.delivery.puppetlabs.net/api/v2 --json 2>/dev/null
{
  "job_id": "1598302813223",
  "centos-7-x86_64": [
    "cosmic-handgun.delivery.puppetlabs.net"
  ]
}
```

----

⚠️  The failing spec test is trying to ensure that ABS' hash matches VMPooler's hash:

```
Failures:

  1) ABS#format returns an hash formatted like a vmpooler return
     Failure/Error: expect(vmpooler_formatted_response).to eq(vmpooler_formatted_compare)

       expected: {"centos-7.2-x86_64"=>{"hostname"=>["aaaaaaaaaaaaaaa.delivery.puppetlabs.net", "aaaaaaaaaaaaaab.deliv....net"]}, "ok"=>true, "ubuntu-7.2-x86_64"=>{"hostname"=>["aaaaaaaaaaaaaac.delivery.puppetlabs.net"]}}
            got: {"centos-7.2-x86_64"=>{"hostname"=>["aaaaaaaaaaaaaaa.delivery.puppetlabs.net", "aaaaaaaaaaaaaab.deliv...567890", "ok"=>true, "ubuntu-7.2-x86_64"=>{"hostname"=>["aaaaaaaaaaaaaac.delivery.puppetlabs.net"]}}

       (compared using ==)

       Diff:
       @@ -1,2 +1,3 @@
        "centos-7.2-x86_64" => {"hostname"=>["aaaaaaaaaaaaaaa.delivery.puppetlabs.net", "aaaaaaaaaaaaaab.delivery.puppetlabs.net"]},
       +"job_id" => "1234567890",
        "ok" => true,

     # ./spec/vmfloaty/abs_spec.rb:32:in `block (3 levels) in <top (required)>'

Finished in 0.62604 seconds (files took 0.63166 seconds to load)
113 examples, 1 failure
```

but I'm not sure that's a correct invariant really 🤔 