### PR TITLE
ABS enables fallback to vmpooler for some scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,20 @@ Now vmfloaty will use those config files if no flag was specified.
 
 #### Default to Puppet's ABS instead of vmpooler
 
+When the --service is not specified on the command line, the first one is selected, so put ABS first.
+Also provide a "vmpooler" service that ABS can use as fallback for operations targeting vmpooler directly
 ```yaml
 # file at ~/.vmfloaty.yml
-url: 'https://abs.example.net'
-user: 'brian'
-token: 'tokenstring'
-type: 'abs'
+services:
+  abs:
+    url: 'https://abs/api/v2'
+    type: 'abs'
+    user: 'samuel'
+    token: 'foo'
+  vmpooler:
+    url: 'http://vmpooler'
+    user: 'samuel'
+    token: 'bar'
 ```
 
 #### Configuring multiple services


### PR DESCRIPTION
## Status

[Ready for Merge]

## Description
 The main goal for this PR is to enable using all of the vmfloaty scenarios when

the service is set to ABS. Since ABS does not implement all the services, it
fallsback on vmpooler when needed (example increasing the lifetime value)

- Validating JSON can be parsed before parsing, as it used to throw uncaught errors
- self.list_active is returning hosts for both nspooler and vmpooler but was returning
job_ids for abs. Now standardized the returned values for use in the "modify" cli,
and created a separate list_active_job_ids for the cases where a job_id list is expected.
Fixes the bug where modify would try to run on job_ids

- added a way to change the service in place for methods that do not make sense
for ABS, and instead fallback on using vmpooler in those cases:
  - 1. summary
  - 2. modify
  - 3. snapshot
  - 4. revert
  - 5. disk
For those methods in the class itself, raising a NoMethodError, in case it is used directly

- query now returns the queue info. For information on VMs, users should use --service vmpooler
- pretty_print_hosts (used in list, and delete scenarios) will now print the job_id
ABS information and indent each VM within and print it's metadata. Useful for
knowing the running time and extending it.

- added a new utility method to get the config for the vmpooler service, used for the fallback
- added a passthrough for the vmpooler token to use when running ABS. This enables
vmpooler to track the VMs used by each token (user). Also aligns the list between
both ABS and vmpooler. Fixes the bit-bar issue where the VMs do not appear when created
via ABS



## Related Issues

- Fix using ABS and vmpooler, need to set a ~./vmfloaty.yaml

```
services:
  abs:
    url: 'https://abs/api/v2'
    type: 'abs'
    user: 'samuel'
    token: 'foo'
  vmpooler:
    url: 'http://vmpooler'
    user: 'samuel'
    token: 'bar'
```

## Todos

- [x] Tests
- [x] Documentation

## Reviewers

@puppetlabs/dio
@highb
@briancain
