### PR TITLE
( DIO-911) Include job_id in ABS --json output

### DIFF
--- a/lib/vmfloaty/abs.rb
+++ b/lib/vmfloaty/abs.rb
@@ -233,7 +233,7 @@ class ABS
 
     (1..retries).each do |i|
       queue_place, res_body = check_queue(conn, saved_job_id, req_obj, verbose)
-      return translated(res_body) if res_body
+      return translated(res_body, saved_job_id) if res_body
 
       sleep_seconds = 10 if i >= 10
       sleep_seconds = i if i < 10
@@ -247,8 +247,8 @@ class ABS
   #
   # We should fix the ABS API to be more like the vmpooler or nspooler api, but for now
   #
-  def self.translated(res_body)
-    vmpooler_formatted_body = {}
+  def self.translated(res_body, job_id)
+    vmpooler_formatted_body = {'job_id' => job_id}
 
     res_body.each do |host|
       if vmpooler_formatted_body[host['type']] && vmpooler_formatted_body[host['type']]['hostname'].class == Array

--- a/lib/vmfloaty/utils.rb
+++ b/lib/vmfloaty/utils.rb
@@ -45,6 +45,10 @@ class Utils
 
     result = {}
 
+    # ABS has a job_id associated with hosts so pass that along
+    abs_job_id = response_body.delete('job_id')
+    result['job_id'] = abs_job_id unless abs_job_id.nil?
+
     filtered_response_body = response_body.reject { |key, _| key == 'request_id' || key == 'ready' }
     filtered_response_body.each do |os, value|
       hostnames = Array(value['hostname'])
@@ -57,7 +61,8 @@ class Utils
 
   def self.format_host_output(hosts)
     hosts.flat_map do |os, names|
-      names.map { |name| "- #{name} (#{os})" }
+      # Assume hosts are stored in Arrays and ignore everything else
+      names.map { |name| "- #{name} (#{os})" } if names.is_a? Array
     end.join("\n")
   end
 

--- a/spec/vmfloaty/abs_spec.rb
+++ b/spec/vmfloaty/abs_spec.rb
@@ -10,14 +10,15 @@ describe ABS do
   end
 
   describe '#format' do
-    it 'returns an hash formatted like a vmpooler return' do
+    it 'returns an hash formatted like a vmpooler return, plus the job_id' do
+      job_id = "generated_by_floaty_12345"
       abs_formatted_response = [
         { 'hostname' => 'aaaaaaaaaaaaaaa.delivery.puppetlabs.net', 'type' => 'centos-7.2-x86_64', 'engine' => 'vmpooler' },
         { 'hostname' => 'aaaaaaaaaaaaaab.delivery.puppetlabs.net', 'type' => 'centos-7.2-x86_64', 'engine' => 'vmpooler' },
         { 'hostname' => 'aaaaaaaaaaaaaac.delivery.puppetlabs.net', 'type' => 'ubuntu-7.2-x86_64', 'engine' => 'vmpooler' },
       ]
 
-      vmpooler_formatted_response = ABS.translated(abs_formatted_response)
+      vmpooler_formatted_response = ABS.translated(abs_formatted_response, job_id)
 
       vmpooler_formatted_compare = {
         'centos-7.2-x86_64' => {},
@@ -28,6 +29,8 @@ describe ABS do
       vmpooler_formatted_compare['ubuntu-7.2-x86_64']['hostname'] = ['aaaaaaaaaaaaaac.delivery.puppetlabs.net']
 
       vmpooler_formatted_compare['ok'] = true
+
+      vmpooler_formatted_compare['job_id'] = job_id
 
       expect(vmpooler_formatted_response).to eq(vmpooler_formatted_compare)
       vmpooler_formatted_response.delete('ok')


### PR DESCRIPTION
## Status

[Ready for Merge]

## Description

Based on the contribution from @nwolfe #92 Thanks! I think clients should not fail if the job_id is added to json as long as it is valid JSON they should just ignore it.
I just fixed the tests.
See an example of using the foaty as a gem in a draft PR for beaker-abs (https://github.com/puppetlabs/beaker-abs/pull/18)

## Related Issues

- Need to be able to get the job_id when running ABS, to be able to return the resources at the end.

## Todos

- [x] Tests
- [x] Documentation

## Reviewers

@puppetlabs/dio
@highb
@briancain
@nwolfe 
