### PR TITLE
Update completion scripts for `service` subcommands

### DIFF
--- a/extras/completions/floaty.bash
+++ b/extras/completions/floaty.bash
@@ -2,29 +2,37 @@
 
 _vmfloaty()
 {
-  local cur prev subcommands template_subcommands hostname_subcommands
+  local cur prev commands template_arg_commands hostname_arg_commands service_subcommands
+
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-  subcommands="delete get help list modify query revert service snapshot ssh status summary token"
-  template_subcommands="get ssh"
-  hostname_subcommands="delete modify query revert snapshot"
+  commands="delete get help list modify query revert service snapshot ssh status summary token"
+  template_arg_commands="get ssh"
+  hostname_arg_commands="delete modify query revert snapshot"
+  service_subcommands="types examples"
 
   if [[ $cur == -* ]] ; then
     # TODO: option completion
     COMPREPLY=()
-  elif [[ $template_subcommands =~ (^| )$prev($| ) ]] ; then
+  elif [[ $template_arg_commands =~ (^| )$prev($| ) ]] ; then
     if [[ -z "$_vmfloaty_avail_templates" ]] ; then
+      # TODO: need a --hostnameonly equivalent here because the section headers of
+      # `floaty list` are adding some spurious entries (including files in current
+      # directory because part of the headers is `**` which is getting expanded)
       _vmfloaty_avail_templates=$(floaty list 2>/dev/null)
     fi
 
     COMPREPLY=( $(compgen -W "${_vmfloaty_avail_templates}" -- "${cur}") )
-  elif [[ $hostname_subcommands =~ (^| )$prev($| ) ]] ; then
+  elif [[ $hostname_arg_commands =~ (^| )$prev($| ) ]] ; then
     _vmfloaty_active_hostnames=$(floaty list --active --hostnameonly 2>/dev/null)
     COMPREPLY=( $(compgen -W "${_vmfloaty_active_hostnames}" -- "${cur}") )
-  else
-    COMPREPLY=( $(compgen -W "${subcommands}" -- "${cur}") )
+  elif [[ "service" == $prev ]] ; then
+    COMPREPLY=( $(compgen -W "${service_subcommands}" -- "${cur}") )
+  elif [[ $1 == $prev ]] ; then
+    # only show top level commands we are at root
+    COMPREPLY=( $(compgen -W "${commands}" -- "${cur}") )
   fi
 }
 complete -F _vmfloaty floaty

--- a/extras/completions/floaty.zsh
+++ b/extras/completions/floaty.zsh
@@ -1,26 +1,32 @@
 _floaty()
 {
-  local line subcommands template_subcommands hostname_subcommands
+  local line commands template_arg_commands hostname_arg_commands service_subcommands
 
-  subcommands="delete get help list modify query revert snapshot ssh status summary token"
+  commands="delete get help list modify query revert service snapshot ssh status summary token"
 
-  template_subcommands=("get" "ssh")
-  hostname_subcommands=("delete" "modify" "query" "revert" "snapshot")
+  template_arg_commands=("get" "ssh")
+  hostname_arg_commands=("delete" "modify" "query" "revert" "snapshot")
+  service_subcommands=("types" "examples")
 
   _arguments -C \
-    "1: :(${subcommands})" \
+    "1: :(${commands})" \
     "*::arg:->args"
 
-  if ((template_subcommands[(Ie)$line[1]])); then
+  if ((template_arg_commands[(Ie)$line[1]])); then
     _floaty_template_sub
-  elif ((hostname_subcommands[(Ie)$line[1]])); then
+  elif ((hostname_arg_commands[(Ie)$line[1]])); then
     _floaty_hostname_sub
+  elif [[ "service" == $line[1] ]]; then
+    _arguments "1: :(${service_subcommands})"
   fi
 }
 
 _floaty_template_sub()
 {
   if [[ -z "$_vmfloaty_avail_templates" ]] ; then
+    # TODO: need a --hostnameonly equivalent here because the section headers of
+    # `floaty list` are adding some spurious entries (including files in current
+    # directory because part of the headers is `**` which is getting expanded)
     _vmfloaty_avail_templates=$(floaty list 2>/dev/null)
   fi
 


### PR DESCRIPTION
Ping @genebean 

This looks a little more complicated than it really is because I renamed the variables to make a little more sense.

Note the `TODO` comment about needing a `--hostnameonly` equivalent of the available templates list, right now the section headings (e.g. `*** NSPOOLER Pools ***`) are causing some spurious entries to be included in the completion options for `get` and `ssh`. I didn't have time to add that option to control `floaty list` output for this PR though. (Perhaps we can rename `--hostnameonly` to `--nameonly` and have it apply to both forms of `floaty list` output?)