### PR TITLE
(maint) Add vmpooler_fallback to the get service check

### DIFF
--- a/lib/vmfloaty/utils.rb
+++ b/lib/vmfloaty/utils.rb
@@ -254,6 +254,7 @@ class Utils
       'url'   => config['url'],
       'user'  => config['user'],
       'token' => config['token'],
+      'vmpooler_fallback' => config['vmpooler_fallback'],
       'type'  => config['type'] || 'vmpooler',
     }
 


### PR DESCRIPTION
Previously the vmpooler_fallback setting was not being recognizied, this
PR will fix it.

## Status

[Ready for Merge | In Progress | ???]

## Description

FIXME

## Related Issues

-

## Todos

- [ ] Tests
- [ ] Documentation

## Reviewers

@puppetlabs/dio
@highb
@briancain
