### PR TITLE
(maint) Don't require configuration file for get

### DIFF
--- a/lib/vmfloaty/abs.rb
+++ b/lib/vmfloaty/abs.rb
@@ -249,7 +249,6 @@ class ABS
     conn.headers['X-AUTH-TOKEN'] = token if token
 
     saved_job_id = DateTime.now.strftime('%Q')
-    vmpooler_config = Utils.get_vmpooler_service_config(config['vmpooler_fallback'])
     req_obj = {
       :resources => os_types,
       :job       => {
@@ -258,8 +257,13 @@ class ABS
           :user => user,
         },
       },
-      :vm_token => vmpooler_config['token'] # request with this token, on behalf of this user
     }
+
+    if config['vmpooler_fallback']
+      vmpooler_config = Utils.get_vmpooler_service_config(config['vmpooler_fallback'])
+      # request with this token, on behalf of this user
+      req_obj[:vm_token] = vmpooler_config['token']
+    end
 
     if config['priority']
       req_obj[:priority] = if config['priority'] == 'high'


### PR DESCRIPTION
Make the vmpooler_fallback optional for cases when there's no
configuration file and everything is specified on the CLI invocation.

## Reviewers

@puppetlabs/dio
@highb
@briancain
