### PR TITLE
(maint) Don't require config file for list --active

### DIFF
--- a/lib/vmfloaty/utils.rb
+++ b/lib/vmfloaty/utils.rb
@@ -116,7 +116,7 @@ class Utils
 
         output_target.puts "- [JobID:#{host_data['request']['job']['id']}] <#{host_data['state']}>"
         host_data['allocated_resources'].each do |allocated_resources, _i|
-          if allocated_resources['engine'] == "vmpooler"
+          if allocated_resources['engine'] == "vmpooler" && service.config["vmpooler_fallback"]
             vmpooler_service = service.clone
             vmpooler_service.silent = true
             vmpooler_service.maybe_use_vmpooler

--- a/spec/vmfloaty/utils_spec.rb
+++ b/spec/vmfloaty/utils_spec.rb
@@ -5,6 +5,11 @@ require 'json'
 require 'commander/command'
 require_relative '../../lib/vmfloaty/utils'
 
+# allow changing config in service for tests
+class Service
+  attr_writer :config
+end
+
 describe Utils do
   describe '#standardize_hostnames' do
     before :each do
@@ -441,9 +446,19 @@ describe Utils do
       end
 
       let(:default_output_first_line) { "- [JobID:#{hostname}] <allocated>" }
-      let(:default_output_second_line) { "  - #{fqdn} (#{template}, 7.67/48 hours, user: bob, role: agent)" }
+      let(:default_output_second_line) { "  - #{fqdn} (#{template})" }
 
       it 'prints output with job id, host, and template' do
+        expect(STDOUT).to receive(:puts).with(default_output_first_line)
+        expect(STDOUT).to receive(:puts).with(default_output_second_line)
+
+        subject
+      end
+
+      it 'prints more information when vmpooler_fallback is set output with job id, host, template, lifetime, user and role' do
+        fallback = {'vmpooler_fallback' => 'vmpooler'}
+        service.config.merge! fallback
+        default_output_second_line="  - #{fqdn} (#{template}, 7.67/48 hours, user: bob, role: agent)"
         expect(STDOUT).to receive(:puts).with(default_output_first_line)
         expect(STDOUT).to receive(:puts).with(default_output_second_line)
 
@@ -529,7 +544,7 @@ describe Utils do
       end
 
       let(:default_output_first_line) { "- [JobID:#{hostname}] <allocated>" }
-      let(:default_output_second_line) { "  - #{fqdn} (#{template}, 7.67/48 hours, user: bob, role: agent)" }
+      let(:default_output_second_line) { "  - #{fqdn} (#{template})" }
       let(:default_output_third_line) { "  - #{fqdn_ns} (#{template_ns})" }
 
       it 'prints output with job id, host, and template' do


### PR DESCRIPTION

## Status

[Ready for Merge]

## Description

Will fallback to printing ABS information, which is less than what you
get if vmpooler_fallback is available

## Related Issues

-

## Todos

- [x] Tests
- [x] Documentation

## Reviewers

@puppetlabs/dio
@highb
@briancain
