### PR TITLE
(maint) Fix bug with detecting ABS service

### DIFF
--- a/lib/vmfloaty/service.rb
+++ b/lib/vmfloaty/service.rb
@@ -139,7 +139,7 @@ class Service
 
   # some methods do not exist for ABS, and if possible should target the Pooler service
   def maybe_use_vmpooler
-    if @service_object.is_a?(ABS.class)
+    if @service_object == ABS # this is not an instance
       if !self.silent
         FloatyLogger.info "The service in use is ABS, but the requested method should run against vmpooler directly, using fallback_vmpooler config from ~/.vmfloaty.yml"
         self.silent = true


### PR DESCRIPTION
## Status

[Ready for Merge]

## Description

Before this change the code would try to check if an object was ABS
by using is_a? which is only for instances of a class. It also compared
with ABS.class which returns the Class class.
Now fixed by comparing the object to the static class

## Related Issues

-

## Todos

- [x] Tests
- [ ] Documentation

## Reviewers

@puppetlabs/dio
@highb
@briancain
