### PR TITLE
(maint) Add more uniqueness to jobid and useful termination message

### DIFF
--- a/lib/vmfloaty/abs.rb
+++ b/lib/vmfloaty/abs.rb
@@ -248,7 +248,7 @@ class ABS
     conn = Http.get_conn(verbose, url)
     conn.headers['X-AUTH-TOKEN'] = token if token
 
-    saved_job_id = DateTime.now.strftime('%Q')
+    saved_job_id = user + "-" + DateTime.now.strftime('%Q')
     vmpooler_config = Utils.get_vmpooler_service_config(config['vmpooler_fallback'])
     req_obj = {
       :resources => os_types,

--- a/lib/vmfloaty/abs.rb
+++ b/lib/vmfloaty/abs.rb
@@ -284,15 +284,20 @@ class ABS
 
     validate_queue_status_response(res.status, res.body, "Initial request", verbose)
 
-    (1..retries).each do |i|
-      queue_place, res_body = check_queue(conn, saved_job_id, req_obj, verbose)
-      return translated(res_body, saved_job_id) if res_body
+    begin
+      (1..retries).each do |i|
+        queue_place, res_body = check_queue(conn, saved_job_id, req_obj, verbose)
+        return translated(res_body, saved_job_id) if res_body
 
-      sleep_seconds = 10 if i >= 10
-      sleep_seconds = i if i < 10
-      FloatyLogger.info "Waiting #{sleep_seconds} seconds to check if ABS request has been filled.  Queue Position: #{queue_place}... (x#{i})"
+        sleep_seconds = 10 if i >= 10
+        sleep_seconds = i if i < 10
+        FloatyLogger.info "Waiting #{sleep_seconds} seconds to check if ABS request has been filled.  Queue Position: #{queue_place}... (x#{i})"
 
-      sleep(sleep_seconds)
+        sleep(sleep_seconds)
+      end
+    rescue SystemExit, Interrupt
+      FloatyLogger.info "\n\nFloaty interrupted, you can query the state of your request via\n1) `floaty query #{saved_job_id}` or delete it via\n2) `floaty delete #{saved_job_id}`"
+      exit 1
     end
     nil
   end


### PR DESCRIPTION
## Status

[Ready for Merge]

## Description

Before this change there was a non zero chance that two requests could be received
at the same millisecond and have the same jobid. Added the username as a prefix
to the job id. Also returns a useful message when ctrl-c or terminating the app while
in the ABS loop.

## Related Issues

-

## Todos

- [ ] Tests
- [ ] Documentation

## Reviewers

@puppetlabs/dio
@highb
@briancain
