### PR TITLE
(DIO-908) Floaty can now report the status of ABS requests

### DIFF
--- a/lib/vmfloaty.rb
+++ b/lib/vmfloaty.rb
@@ -40,8 +40,12 @@ class Vmfloaty
       c.option '--json', 'Prints retrieved vms in JSON format'
       c.option '--ondemand', 'Requested vms are provisioned upon receival of the request, tracked by a request ID'
       c.option '--continue STRING', String, 'resume polling ABS for job_id, for use when the cli was interrupted'
+      c.option '--loglevel STRING', String, 'the log level to use (debug, info, error)'
       c.action do |args, options|
         verbose = options.verbose || config['verbose']
+        if options.loglevel
+          FloatyLogger.setlevel = options.loglevel
+        end
         service = Service.new(options, config)
         use_token = !options.notoken
         force = options.force
@@ -93,8 +97,12 @@ class Vmfloaty
       c.option '--token STRING', String, 'Token for pooler service'
       c.option '--url STRING', String, 'URL of pooler service'
       c.option '--user STRING', String, 'User to authenticate with'
+      c.option '--loglevel STRING', String, 'the log level to use (debug, info, error)'
       c.action do |args, options|
         verbose = options.verbose || config['verbose']
+        if options.loglevel
+          FloatyLogger.setlevel = options.loglevel
+        end
 
         service = Service.new(options, config)
         filter = args[0]
@@ -230,8 +238,13 @@ class Vmfloaty
       c.option '--token STRING', String, 'Token for pooler service'
       c.option '--url STRING', String, 'URL of pooler service'
       c.option '--user STRING', String, 'User to authenticate with'
+      c.option '--loglevel STRING', String, 'the log level to use (debug, info, error)'
       c.action do |args, options|
         verbose = options.verbose || config['verbose']
+        if options.loglevel
+          FloatyLogger.setlevel = options.loglevel
+        end
+
         service = Service.new(options, config)
         hostnames = args[0]
         delete_all = options.all
@@ -375,8 +388,12 @@ class Vmfloaty
       c.option '--service STRING', String, 'Configured pooler service name'
       c.option '--url STRING', String, 'URL of pooler service'
       c.option '--json', 'Prints status in JSON format'
+      c.option '--loglevel STRING', String, 'the log level to use (debug, info, error)'
       c.action do |_, options|
         verbose = options.verbose || config['verbose']
+        if options.loglevel
+          FloatyLogger.setlevel = options.loglevel
+        end
         service = Service.new(options, config)
         if options.json
           pp service.status(verbose)

--- a/lib/vmfloaty/logger.rb
+++ b/lib/vmfloaty/logger.rb
@@ -17,6 +17,19 @@ class FloatyLogger < ::Logger
     FloatyLogger.logger.error msg
   end
 
+  def self.setlevel=(level)
+    level = level.downcase
+    if level == "debug"
+      self.logger.level = ::Logger::DEBUG
+    elsif level == "info"
+      self.logger.level = ::Logger::INFO
+    elsif level == "error"
+      self.logger.level = ::Logger::ERROR
+    else
+      error("set loglevel to debug, info or error")
+    end
+  end
+
   def initialize
     super(STDERR)
     self.level = ::Logger::INFO

--- a/lib/vmfloaty/nonstandard_pooler.rb
+++ b/lib/vmfloaty/nonstandard_pooler.rb
@@ -22,7 +22,7 @@ class NonstandardPooler
     status['reserved_hosts'] || []
   end
 
-  def self.retrieve(verbose, os_type, token, url, _user, _options, ondemand = nil)
+  def self.retrieve(verbose, os_type, token, url, _user, _options, ondemand = nil, _continue = nil)
     conn = Http.get_conn(verbose, url)
     conn.headers['X-AUTH-TOKEN'] = token if token
 

--- a/lib/vmfloaty/pooler.rb
+++ b/lib/vmfloaty/pooler.rb
@@ -28,7 +28,7 @@ class Pooler
     vms
   end
 
-  def self.retrieve(verbose, os_type, token, url, _user, _options, ondemand = nil)
+  def self.retrieve(verbose, os_type, token, url, _user, _options, ondemand = nil, _continue = nil)
     # NOTE:
     #   Developers can use `Utils.generate_os_hash` to
     #   generate the os_type param.

--- a/lib/vmfloaty/service.rb
+++ b/lib/vmfloaty/service.rb
@@ -77,10 +77,10 @@ class Service
     @service_object.list_active verbose, url, token, user
   end
 
-  def retrieve(verbose, os_types, use_token = true, ondemand = nil)
+  def retrieve(verbose, os_types, use_token = true, ondemand = nil, continue = nil)
     FloatyLogger.info 'Requesting a vm without a token...' unless use_token
     token_value = use_token ? token : nil
-    @service_object.retrieve verbose, os_types, token_value, url, user, @config, ondemand
+    @service_object.retrieve verbose, os_types, token_value, url, user, @config, ondemand, continue
   end
 
   def wait_for_request(verbose, requestid)

--- a/lib/vmfloaty/utils.rb
+++ b/lib/vmfloaty/utils.rb
@@ -116,7 +116,7 @@ class Utils
 
         output_target.puts "- [JobID:#{host_data['request']['job']['id']}] <#{host_data['state']}>"
         host_data['allocated_resources'].each do |allocated_resources, _i|
-          if allocated_resources['engine'] == "vmpooler" && service.config["vmpooler_fallback"]
+          if (allocated_resources['engine'] == "vmpooler" || allocated_resources['engine'] == 'ondemand') && service.config["vmpooler_fallback"]
             vmpooler_service = service.clone
             vmpooler_service.silent = true
             vmpooler_service.maybe_use_vmpooler


### PR DESCRIPTION


## Status

In Progress

## Description
- If ABS queries returns a body for 200 or 202, floaty will print it
this is useful in the new version of ABS, since it shows the progress
for ondemand requests (AWS or vmpooler)
- removed the queue_place and querying the queue for a 'get' request
this queue_place number was misleading since it was just a redis index
and did not represent well where the request was in the queue
- Also added a flag option --continue to be used when the cli was
interrupted for example with ctrl-c

## Related Issues

-

## Todos

- [ ] Tests
- [ ] Documentation

## Reviewers

@puppetlabs/dio
@highb
@briancain
