### PR TITLE
(DIO-1522) Show the VM state (running, destroyed) and colorize in red…

### DIFF
--- a/lib/vmfloaty/utils.rb
+++ b/lib/vmfloaty/utils.rb
@@ -130,8 +130,13 @@ class Utils
         tag_pairs = []
         tag_pairs = host_data['tags'].map { |key, value| "#{key}: #{value}" } unless host_data['tags'].nil?
         duration = "#{host_data['running']}/#{host_data['lifetime']} hours"
-        metadata = [host_data['template'], duration, *tag_pairs]
-        output_target.puts "- #{hostname}.#{host_data['domain']} (#{metadata.join(', ')})".gsub(/^/, ' ' * indent)
+        metadata = [host_data['state'], host_data['template'], duration, *tag_pairs]
+        message = "- #{hostname}.#{host_data['domain']} (#{metadata.join(', ')})".gsub(/^/, ' ' * indent)
+        if host_data['state'] && host_data['state'] == "destroyed"
+          output_target.puts message.colorize(:red)
+        else
+          output_target.puts message
+        end
       when 'NonstandardPooler'
         line = "- #{host_data['fqdn']} (#{host_data['os_triple']}"
         line += ", #{host_data['hours_left_on_reservation']}h remaining"

--- a/spec/vmfloaty/utils_spec.rb
+++ b/spec/vmfloaty/utils_spec.rb
@@ -283,7 +283,7 @@ describe Utils do
         }
       end
 
-      let(:default_output) { "- #{fqdn} (ubuntu-1604-x86_64, 9.66/12 hours)" }
+      let(:default_output) { "- #{fqdn} (running, ubuntu-1604-x86_64, 9.66/12 hours)" }
 
       it 'prints output with host fqdn, template and duration info' do
         expect(STDOUT).to receive(:puts).with(default_output)
@@ -311,7 +311,7 @@ describe Utils do
         end
 
         it 'prints output with host fqdn, template, duration info, and tags' do
-          output = "- #{fqdn} (redhat-7-x86_64, 7.67/48 hours, user: bob, role: agent)"
+          output = "- #{fqdn} (running, redhat-7-x86_64, 7.67/48 hours, user: bob, role: agent)"
 
           expect(STDOUT).to receive(:puts).with(output)
 
@@ -458,9 +458,20 @@ describe Utils do
       it 'prints more information when vmpooler_fallback is set output with job id, host, template, lifetime, user and role' do
         fallback = {'vmpooler_fallback' => 'vmpooler'}
         service.config.merge! fallback
-        default_output_second_line="  - #{fqdn} (#{template}, 7.67/48 hours, user: bob, role: agent)"
+        default_output_second_line="  - #{fqdn} (running, #{template}, 7.67/48 hours, user: bob, role: agent)"
         expect(STDOUT).to receive(:puts).with(default_output_first_line)
         expect(STDOUT).to receive(:puts).with(default_output_second_line)
+
+        subject
+      end
+
+      it 'prints in red when destroyed' do
+        fallback = {'vmpooler_fallback' => 'vmpooler'}
+        service.config.merge! fallback
+        response_body_vmpooler[fqdn_hostname]['state'] = "destroyed"
+        default_output_second_line_red="  - #{fqdn} (destroyed, #{template}, 7.67/48 hours, user: bob, role: agent)".red
+        expect(STDOUT).to receive(:puts).with(default_output_first_line)
+        expect(STDOUT).to receive(:puts).with(default_output_second_line_red)
 
         subject
       end


### PR DESCRIPTION
## Status

Ready for Merge

## Description

… when it has been deleted

the ABS system does not have a real sense of the current state of the resources
it has allocated. When running list --active it can list VMs that have been
deleted or reaped after their lifetime expired.
This change enables to show more information when a vmpooler_fallback service
is provided to ABS, and will show the state (running, destroyed) and colorize
in red when the VM is destroyed.

## Related Issues

-

## Todos

- [ ] Tests
- [ ] Documentation

## Reviewers

@puppetlabs/dio
@highb
@briancain
