### PR TITLE
faraday: allow latest versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,5 @@ group :test do
   gem 'rb-readline'
   gem 'rspec', '~> 3.10.0'
   gem 'rubocop', '~> 1.6'
-  gem 'webmock', '1.21.0'
+  gem 'webmock', '>= 1.21.0'
 end

--- a/vmfloaty.gemspec
+++ b/vmfloaty.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'colorize', '~> 0.8.1'
   s.add_dependency 'commander', '>= 4.4.3', '< 4.6.0'
-  s.add_dependency 'faraday', '~> 0.17.0'
+  s.add_dependency 'faraday', '>= 0.17.0'
 end


### PR DESCRIPTION
latest faraday is required because:
beaker -> beaker-abs -> vmfloaty

and at least in beaker we need the github changelog generator gem and
that requires faraday 1.x

## Status

[Ready for Merge | In Progress | ???]

## Description

FIXME

## Related Issues

-

## Todos

- [ ] Tests
- [ ] Documentation

## Reviewers

@puppetlabs/dio
@highb
@briancain
