### PR TITLE
(maint) Use latest Faraday/webmock, update specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,5 @@ group :test do
   gem 'rb-readline'
   gem 'rspec', '~> 3.10.0'
   gem 'rubocop', '~> 1.6'
-  gem 'webmock', '1.21.0'
+  gem 'webmock', '~> 3.13'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'simplecov'
 require 'coveralls'
+require 'base64'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
                                                                  SimpleCov::Formatter::HTMLFormatter,
@@ -25,4 +26,20 @@ RSpec.configure do |config|
   config.color = true
   config.tty = true
   config.formatter = :documentation
+end
+
+def get_headers(username: nil, password: nil, token: nil, content_type: nil, content_length: nil)
+  headers = {
+    'Accept'          => '*/*',
+    'Accept-Encoding' => /gzip/,
+    'User-Agent'      => /Faraday/,
+  }
+  if username && password
+    auth = Base64.encode64("#{username}:#{password}").chomp
+    headers['Authorization'] = "Basic #{auth}"
+  end
+  headers['X-Auth-Token'] = token if token
+  headers['Content-Type'] = content_type if content_type
+  headers['Content-Length'] = content_length.to_s if content_length
+  headers
 end

--- a/spec/vmfloaty/abs/auth_spec.rb
+++ b/spec/vmfloaty/abs/auth_spec.rb
@@ -3,7 +3,11 @@
 require 'spec_helper'
 require_relative '../../../lib/vmfloaty/auth'
 
+user = 'first.last'
+pass = 'password'
+
 describe Pooler do
+
   before :each do
     @abs_url = 'https://abs.example.com/api/v2'
   end
@@ -15,18 +19,20 @@ describe Pooler do
     end
 
     it 'returns a token from abs' do
-      stub_request(:post, 'https://first.last:password@abs.example.com/api/v2/token')
+      stub_request(:post, 'https://abs.example.com/api/v2/token')
+        .with(headers: get_headers(username: user, password: pass, content_length: 0))
         .to_return(status: 200, body: @get_token_response, headers: {})
 
-      token = Auth.get_token(false, @abs_url, 'first.last', 'password')
+      token = Auth.get_token(false, @abs_url, user, pass)
       expect(token).to eq @token
     end
 
     it 'raises a token error if something goes wrong' do
-      stub_request(:post, 'https://first.last:password@abs.example.com/api/v2/token')
+      stub_request(:post, 'https://abs.example.com/api/v2/token')
+        .with(headers: get_headers(username: user, password: pass, content_length: 0))
         .to_return(status: 500, body: '{"ok":false}', headers: {})
 
-      expect { Auth.get_token(false, @abs_url, 'first.last', 'password') }.to raise_error(TokenError)
+      expect { Auth.get_token(false, @abs_url, user, pass) }.to raise_error(TokenError)
     end
   end
 
@@ -37,22 +43,24 @@ describe Pooler do
     end
 
     it 'deletes the specified token' do
-      stub_request(:delete, 'https://first.last:password@abs.example.com/api/v2/token/utpg2i2xswor6h8ttjhu3d47z53yy47y')
+      stub_request(:delete, 'https://abs.example.com/api/v2/token/utpg2i2xswor6h8ttjhu3d47z53yy47y')
+        .with(headers: get_headers(username: user, password: pass))
         .to_return(status: 200, body: @delete_token_response, headers: {})
 
-      expect(Auth.delete_token(false, @abs_url, 'first.last', 'password',
-                               @token)).to eq JSON.parse(@delete_token_response)
+      expect(Auth.delete_token(false, @abs_url, user, pass,
+                              @token)).to eq JSON.parse(@delete_token_response)
     end
 
     it 'raises a token error if something goes wrong' do
-      stub_request(:delete, 'https://first.last:password@abs.example.com/api/v2/token/utpg2i2xswor6h8ttjhu3d47z53yy47y')
+      stub_request(:delete, 'https://abs.example.com/api/v2/token/utpg2i2xswor6h8ttjhu3d47z53yy47y')
+        .with(headers: get_headers(username: user, password: pass))
         .to_return(status: 500, body: '{"ok":false}', headers: {})
 
-      expect { Auth.delete_token(false, @abs_url, 'first.last', 'password', @token) }.to raise_error(TokenError)
+      expect { Auth.delete_token(false, @abs_url, user, pass, @token) }.to raise_error(TokenError)
     end
 
     it 'raises a token error if no token provided' do
-      expect { Auth.delete_token(false, @abs_url, 'first.last', 'password', nil) }.to raise_error(TokenError)
+      expect { Auth.delete_token(false, @abs_url, user, pass, nil) }.to raise_error(TokenError)
     end
   end
 
@@ -64,7 +72,7 @@ describe Pooler do
 
     it 'checks the status of a token' do
       stub_request(:get, "#{@abs_url}/token/utpg2i2xswor6h8ttjhu3d47z53yy47y")
-        .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3' })
+        .with(headers: get_headers)
         .to_return(status: 200, body: @token_status_response, headers: {})
 
       expect(Auth.token_status(false, @abs_url, @token)).to eq JSON.parse(@token_status_response)
@@ -72,7 +80,7 @@ describe Pooler do
 
     it 'raises a token error if something goes wrong' do
       stub_request(:get, "#{@abs_url}/token/utpg2i2xswor6h8ttjhu3d47z53yy47y")
-        .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3' })
+        .with(headers: get_headers)
         .to_return(status: 500, body: '{"ok":false}', headers: {})
 
       expect { Auth.token_status(false, @abs_url, @token) }.to raise_error(TokenError)

--- a/spec/vmfloaty/abs_spec.rb
+++ b/spec/vmfloaty/abs_spec.rb
@@ -152,7 +152,11 @@ describe ABS do
         [
           { "state":"allocated", "last_processed":"2020-01-17 22:29:13 +0000", "allocated_resources":[{"hostname":"craggy-chord.delivery.puppetlabs.net", "type":"centos-7-x86_64", "engine":"vmpooler"}, {"hostname":"visible-revival.delivery.puppetlabs.net", "type":"centos-7-x86_64", "engine":"vmpooler"}], "audit_log":{"2020-01-17 22:28:45 +0000":"Allocated craggy-chord.delivery.puppetlabs.net, visible-revival.delivery.puppetlabs.net for job 1579300120799"}, "request":{"resources":{"centos-7-x86_64":2}, "job":{"id":"1579300120799", "tags":{"user":"test-user"}, "user":"test-user", "time-received":1579300120}, "priority":3}}
         ]'
-        @return_request = { '{"job_id":"1579300120799","hosts":{"hostname":"craggy-chord.delivery.puppetlabs.net","type":"centos-7-x86_64","engine":"vmpooler"},{"hostname":"visible-revival.delivery.puppetlabs.net","type":"centos-7-x86_64","engine":"vmpooler"}}' => true }
+        @return_request = {
+          "job_id" => "1579300120799",
+          "hosts" => [{"hostname"=>"craggy-chord.delivery.puppetlabs.net","type"=>"centos-7-x86_64","engine"=>"vmpooler"},
+                      {"hostname"=>"visible-revival.delivery.puppetlabs.net","type"=>"centos-7-x86_64","engine"=>"vmpooler"}]
+        }
         # rubocop:enable Layout/LineLength
         @token = 'utpg2i2xswor6h8ttjhu3d47z53yy47y'
         @test_user = 'test-user'
@@ -164,7 +168,7 @@ describe ABS do
         stub_request(:get, 'https://abs.example.com/api/v2/status/queue')
           .to_return(status: 200, body: @active_requests_response, headers: {})
         stub_request(:post, 'https://abs.example.com/api/v2/return')
-          .with(body: @return_request)
+          .with(headers: get_headers(content_type: 'application/x-www-form-urlencoded', token: @token), body: @return_request.to_json)
           .to_return(status: 200, body: 'OK', headers: {})
 
         ret = ABS.delete(false, @abs_url, @hosts, @token, @test_user)

--- a/spec/vmfloaty/auth_spec.rb
+++ b/spec/vmfloaty/auth_spec.rb
@@ -3,6 +3,9 @@
 require 'spec_helper'
 require_relative '../../lib/vmfloaty/auth'
 
+user = 'first.last'
+pass = 'password'
+
 describe Pooler do
   before :each do
     @vmpooler_url = 'https://vmpooler.example.com'
@@ -15,18 +18,20 @@ describe Pooler do
     end
 
     it 'returns a token from vmpooler' do
-      stub_request(:post, 'https://first.last:password@vmpooler.example.com/token')
+      stub_request(:post, 'https://vmpooler.example.com/token')
+        .with(headers: get_headers(username: user, password: pass, content_length: 0))
         .to_return(status: 200, body: @get_token_response, headers: {})
 
-      token = Auth.get_token(false, @vmpooler_url, 'first.last', 'password')
+      token = Auth.get_token(false, @vmpooler_url, user, pass)
       expect(token).to eq @token
     end
 
     it 'raises a token error if something goes wrong' do
-      stub_request(:post, 'https://first.last:password@vmpooler.example.com/token')
+      stub_request(:post, 'https://vmpooler.example.com/token')
+      .with(headers: get_headers(username: user, password: pass, content_length: 0))
         .to_return(status: 500, body: '{"ok":false}', headers: {})
 
-      expect { Auth.get_token(false, @vmpooler_url, 'first.last', 'password') }.to raise_error(TokenError)
+      expect { Auth.get_token(false, @vmpooler_url, user, pass) }.to raise_error(TokenError)
     end
   end
 
@@ -37,15 +42,17 @@ describe Pooler do
     end
 
     it 'deletes the specified token' do
-      stub_request(:delete, 'https://first.last:password@vmpooler.example.com/token/utpg2i2xswor6h8ttjhu3d47z53yy47y')
+      stub_request(:delete, 'https://vmpooler.example.com/token/utpg2i2xswor6h8ttjhu3d47z53yy47y')
+        .with(headers: get_headers(username: user, password: pass))
         .to_return(status: 200, body: @delete_token_response, headers: {})
 
-      expect(Auth.delete_token(false, @vmpooler_url, 'first.last', 'password',
+      expect(Auth.delete_token(false, @vmpooler_url, user, pass,
                                @token)).to eq JSON.parse(@delete_token_response)
     end
 
     it 'raises a token error if something goes wrong' do
-      stub_request(:delete, 'https://first.last:password@vmpooler.example.com/token/utpg2i2xswor6h8ttjhu3d47z53yy47y')
+      stub_request(:delete, 'https://vmpooler.example.com/token/utpg2i2xswor6h8ttjhu3d47z53yy47y')
+        .with(headers: get_headers(username: user, password: pass))
         .to_return(status: 500, body: '{"ok":false}', headers: {})
 
       expect { Auth.delete_token(false, @vmpooler_url, 'first.last', 'password', @token) }.to raise_error(TokenError)
@@ -64,6 +71,7 @@ describe Pooler do
 
     it 'checks the status of a token' do
       stub_request(:get, "#{@vmpooler_url}/token/utpg2i2xswor6h8ttjhu3d47z53yy47y")
+        .with(headers: get_headers)
         .to_return(status: 200, body: @token_status_response, headers: {})
 
       expect(Auth.token_status(false, @vmpooler_url, @token)).to eq JSON.parse(@token_status_response)
@@ -71,6 +79,7 @@ describe Pooler do
 
     it 'raises a token error if something goes wrong' do
       stub_request(:get, "#{@vmpooler_url}/token/utpg2i2xswor6h8ttjhu3d47z53yy47y")
+        .with(headers: get_headers)
         .to_return(status: 500, body: '{"ok":false}', headers: {})
 
       expect { Auth.token_status(false, @vmpooler_url, @token) }.to raise_error(TokenError)

--- a/spec/vmfloaty/nonstandard_pooler_spec.rb
+++ b/spec/vmfloaty/nonstandard_pooler_spec.rb
@@ -8,9 +8,7 @@ require 'vmfloaty/nonstandard_pooler'
 describe NonstandardPooler do
   before :each do
     @nspooler_url = 'https://nspooler.example.com'
-    @auth_token_headers = {
-      'X-Auth-Token' => 'token-value'
-    }
+    @auth_token_headers = get_headers(token: 'token-value')
   end
 
   describe '#list' do
@@ -121,7 +119,7 @@ describe NonstandardPooler do
 
     it 'raises an AuthError if the token is invalid' do
       stub_request(:post, "#{@nspooler_url}/host/solaris-11-sparc")
-        .with(headers: @auth_token_headers)
+        .with(headers: get_headers(token: 'token-value'))
         .to_return(status: 401, body: '{"ok":false,"reason": "token: token-value does not exist"}', headers: {})
 
       vm_hash = { 'solaris-11-sparc' => 1 }
@@ -174,7 +172,7 @@ describe NonstandardPooler do
     end
 
     it 'modifies the reason of a vm' do
-      modify_request_body = { '{"reserved_for_reason":"testing"}' => true }
+      modify_request_body = { '{"reserved_for_reason":"testing"}' => nil }
       stub_request(:put, "#{@nspooler_url}/host/myfakehost")
         .with(body: modify_request_body,
               headers: @auth_token_headers)

--- a/spec/vmfloaty/pooler_spec.rb
+++ b/spec/vmfloaty/pooler_spec.rb
@@ -119,8 +119,8 @@ describe Pooler do
     it 'modifies the TTL of a vm' do
       modify_hash = { lifetime: 12 }
       stub_request(:put, "#{@vmpooler_url}/vm/fq6qlpjlsskycq6")
-        .with(body: { '{"lifetime":12}' => true },
-              headers: { 'Content-Type' => 'application/x-www-form-urlencoded', 'X-Auth-Token' => 'mytokenfile' })
+        .with(body: { '{"lifetime":12}' => nil },
+              headers: get_headers(content_type: 'application/x-www-form-urlencoded', token: 'mytokenfile'))
         .to_return(status: 200, body: @modify_response_body_success, headers: {})
 
       modify_req = Pooler.modify(false, @vmpooler_url, 'fq6qlpjlsskycq6', 'mytokenfile', modify_hash)

--- a/vmfloaty.gemspec
+++ b/vmfloaty.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'colorize', '~> 0.8.1'
   s.add_dependency 'commander', '>= 4.4.3', '< 4.6.0'
-  s.add_dependency 'faraday', '~> 0.17.0'
+  s.add_dependency 'faraday', '~> 1.5', '>= 1.5.1'
 end


### PR DESCRIPTION
This unpins Faraday and webmock, and updates specs so that the Faraday changes (primarily including auth in the header rather than in the URL) is reflected.

## Reviewers

@puppetlabs/dio
