### PR TITLE
(maint) Fix up nspooler list active bug

### DIFF
--- a/lib/vmfloaty/utils.rb
+++ b/lib/vmfloaty/utils.rb
@@ -144,7 +144,7 @@ class Utils
       when 'NonstandardPooler'
         line = "- #{host_data['fqdn']} (#{host_data['os_triple']}"
         line += ", #{host_data['hours_left_on_reservation']}h remaining"
-        line += ", reason: #{host_data['reserved_for_reason']}" unless host_data['reserved_for_reason'].empty?
+        line += ", reason: #{host_data['reserved_for_reason']}" unless  host_data['reserved_for_reason'].nil? || host_data['reserved_for_reason'].empty?
         line += ')'
         output_target.puts line
       else


### PR DESCRIPTION
If no reason is defined for checking out a nspooler VM we'd get a nil
reference error message when listing active nspooler VMs. This PR fixes
that.