### PR TITLE
(maint) Add Ruby 3.1 to test matrix + dockerfile and drop EOL Ruby 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.1-slim-buster
+FROM ruby:3.1.1-slim-buster
 
 COPY ./ ./
 


### PR DESCRIPTION
## Description

Add Ruby 3.1 and remove 2.6 as it is now EOL.


