### PR TITLE
Migrate issue management to Jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A CLI helper tool for [Puppet's VMPooler](https://github.com/puppetlabs/vmpooler
     - [Example Projects](#example-projects)
   - [Contributing](#contributing)
     - [Code Reviews](#code-reviews)
+  - [Submitting Issues](#submitting-issues)
   - [Releasing](#releasing)
   - [Special thanks](#special-thanks)
 
@@ -185,6 +186,10 @@ PR's are welcome! We always love to see how others think this tool can be made b
 ### Code Reviews
 
 Please wait for multiple code owners to sign off on any notable change.
+
+## Submitting Issues
+
+Please file any issues or requests in Jira at <https://puppet.atlassian.net/jira/software/c/projects/POOLER/issues> where project development is tracked across all VMPooler related components.
 
 ## Releasing
 


### PR DESCRIPTION
This is to propose moving issue management to the public Jira project at https://puppet.atlassian.net/jira/software/c/projects/POOLER/issues. If this sounds good, then post merge I'll create a Jira ticket for any open GitHub issues, close the GitHub issue with reference to the Jira ticket, and disable issues on the repository.