### PR TITLE
(RE-15687) Use relative path for pooler status and summary

### DIFF
--- a/lib/vmfloaty/pooler.rb
+++ b/lib/vmfloaty/pooler.rb
@@ -146,14 +146,14 @@ class Pooler
   def self.status(verbose, url)
     conn = Http.get_conn(verbose, url)
 
-    response = conn.get '/status'
+    response = conn.get 'status'
     JSON.parse(response.body)
   end
 
   def self.summary(verbose, url)
     conn = Http.get_conn(verbose, url)
 
-    response = conn.get '/summary'
+    response = conn.get 'summary'
     JSON.parse(response.body)
   end
 


### PR DESCRIPTION
Fixes https://github.com/puppetlabs/vmfloaty/issues/185

For requests to the `/status` and `/summary` endpoints, use a relative path instead of an absolute path, since the generic non api version specific paths were removed in v3.

This should be backwards compatible with v2 (API v1 and v2) since those api specific paths existed in previous versions. v3 removed the generic reroute path: https://github.com/puppetlabs/vmpooler/blob/16d23a0226372bcab342c046b94b9832dc0a58ba/lib/vmpooler/api/v1.rb#L648